### PR TITLE
Fix side panel open/close

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -12,13 +12,6 @@
   <p>Use the buttons below to open or close the side panel.</p>
   <button id="openPanel">Open Side Panel</button>
   <button id="closePanel">Close Side Panel</button>
-  <script>
-    document.getElementById('openPanel').addEventListener('click', () => {
-      chrome.sidePanel.open({ windowId: chrome.windows.WINDOW_ID_CURRENT });
-    });
-    document.getElementById('closePanel').addEventListener('click', () => {
-      chrome.sidePanel.close({ windowId: chrome.windows.WINDOW_ID_CURRENT });
-    });
-  </script>
+  <script src="popup.js"></script>
 </body>
 </html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const openBtn = document.getElementById('openPanel');
+  const closeBtn = document.getElementById('closePanel');
+
+  openBtn.addEventListener('click', () => {
+    chrome.sidePanel
+      .setOptions({ path: 'sidepanel.html', enabled: true })
+      .then(() => {
+        chrome.sidePanel.open({ windowId: chrome.windows.WINDOW_ID_CURRENT });
+      })
+      .catch((err) => console.error('Failed to open side panel', err));
+  });
+
+  closeBtn.addEventListener('click', () => {
+    chrome.sidePanel
+      .close({ windowId: chrome.windows.WINDOW_ID_CURRENT })
+      .catch((err) => console.error('Failed to close side panel', err));
+  });
+});


### PR DESCRIPTION
## Summary
- improve popup script to ensure side panel opens and closes correctly
- call `chrome.sidePanel.setOptions` before opening
- log errors if open/close fails

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_685d3beb116483208972497668939904