### PR TITLE
Add creation of prompts/folders and improve styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,21 @@ ChatGPT Prompt Manager is a Chrome extension that lets you store your favorite p
 
 ## Features
 - Add/modify and remove prompts from the library
-- Save prompts in folders for easy organization
+- Save prompts in folders for easy organization or create new folders on the fly
+- Create prompts with name, description, tags and associated folder
 - Inject any saved prompt directly into ChatGPT
-- Import/export your prompt library as CSV
+- Import/export your prompt library as JSON
 - Search for prompts with the search bar
 - Add/remove your prompts from favorites
 - Add tags to prompts to ease their search
+- Button on the right side of chatGPT.com to open/close the prompt manager sidebar
+- Dark themed sidebar for better readability
 
-The prompts are organised as cards with buttons on it to modify, add/remove from favorites and paste to the ChatGPT textbox on either chat.openai.com or chatgpt.com.
+The prompts are organised as cards with buttons to modify, add/remove from favorites, delete and paste to the ChatGPT textbox.
 
 ## Installation
 1. Open Chrome and navigate to `chrome://extensions`.
 2. Enable **Developer mode**.
 3. Click **Load unpacked** and select the `extension` folder of this repository.
 
-After loading the extension you will see a new action icon. Clicking it opens a small settings popup. Use the browser side panel to manage your prompts. In the sidebar you can add new entries using the form, filter them with the search bar and edit each prompt from its card. Your library is stored locally in Chrome.
+After loading the extension visit [chatgpt.com](https://chatgpt.com/) and use the **Prompts** button on the right side of the page to open the sidebar. Use the **New Prompt** and **New Folder** buttons to create entries, filter them with the search bar and edit each prompt from its card. Your library is stored locally in Chrome.

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -1,0 +1,202 @@
+(function() {
+  // Create toggle button
+  const toggleBtn = document.createElement('div');
+  toggleBtn.id = 'pm-toggle-btn';
+  toggleBtn.textContent = 'Prompts';
+  document.body.appendChild(toggleBtn);
+
+  // Create sidebar
+  const sidebar = document.createElement('div');
+  sidebar.id = 'pm-sidebar';
+  sidebar.innerHTML = `
+    <input type="text" placeholder="Search" class="pm-search" id="pm-search" />
+    <div class="pm-actions">
+      <button id="pm-new-folder">New Folder</button>
+      <button id="pm-new-prompt">New Prompt</button>
+    </div>
+    <div class="pm-folder-list" id="pm-folders"></div>
+    <div class="pm-prompt-list" id="pm-prompts"></div>
+    <div id="pm-settings-btn">Settings</div>
+  `;
+  document.body.appendChild(sidebar);
+
+  toggleBtn.addEventListener('click', () => {
+    sidebar.classList.toggle('open');
+  });
+
+  // Utilities
+  function loadData() {
+    return new Promise(resolve => {
+      chrome.storage.local.get(['folders', 'prompts'], data => {
+        resolve({
+          folders: data.folders || [],
+          prompts: data.prompts || []
+        });
+      });
+    });
+  }
+
+  function saveData(folders, prompts) {
+    chrome.storage.local.set({ folders, prompts });
+  }
+
+  function renderFolders(folders) {
+    const container = document.getElementById('pm-folders');
+    container.innerHTML = '';
+    folders.slice(0,4).forEach(f => {
+      const div = document.createElement('div');
+      div.className = 'pm-folder';
+      div.textContent = f.name;
+      container.appendChild(div);
+    });
+    if (folders.length > 4) {
+      const more = document.createElement('div');
+      more.className = 'pm-folder';
+      more.textContent = '...';
+      container.appendChild(more);
+    }
+  }
+
+  function renderPrompts(prompts) {
+    const container = document.getElementById('pm-prompts');
+    container.innerHTML = '';
+    prompts.forEach(p => {
+      const card = document.createElement('div');
+      card.className = 'pm-card';
+      card.innerHTML = `
+        <div class="pm-card-header">
+          <strong>${p.name}</strong>
+          <span class="pm-card-actions">
+            <button data-action="fav">${p.favorite ? '★' : '☆'}</button>
+            <button data-action="edit">✎</button>
+            <button data-action="del">🗑</button>
+          </span>
+        </div>
+        <div class="pm-card-body">${(p.description || p.text).substring(0, 60)}...</div>
+      `;
+      card.addEventListener('click', e => {
+        if (e.target.tagName === 'BUTTON') return; // ignore button clicks
+        insertPrompt(p.text);
+      });
+      card.querySelector('[data-action="fav"]').addEventListener('click', () => {
+        p.favorite = !p.favorite;
+        saveCurrent();
+      });
+      card.querySelector('[data-action="edit"]').addEventListener('click', () => {
+        const newName = prompt('Prompt name', p.name);
+        if (!newName) return;
+        const newDesc = prompt('Prompt description', p.description || '');
+        const newText = prompt('Prompt text', p.text);
+        if (!newText) return;
+        const newTags = prompt('Tags (comma separated)', (p.tags || []).join(', ')) || '';
+        const newFolder = prompt('Folder id (leave empty for none)', p.folderId || '') || '';
+        p.name = newName;
+        p.description = newDesc || '';
+        p.text = newText;
+        p.tags = newTags.split(',').map(t => t.trim()).filter(Boolean);
+        p.folderId = newFolder;
+        saveCurrent();
+      });
+      card.querySelector('[data-action="del"]').addEventListener('click', () => {
+        current.prompts = current.prompts.filter(x => x.id !== p.id);
+        saveCurrent();
+      });
+      container.appendChild(card);
+    });
+  }
+
+  function insertPrompt(text) {
+    const textarea = document.querySelector('textarea');
+    if (!textarea) return;
+    textarea.value = text;
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.focus();
+  }
+
+  let current = { folders: [], prompts: [] };
+
+  function saveCurrent() {
+    saveData(current.folders, current.prompts);
+    render();
+  }
+
+  function render() {
+    renderFolders(current.folders);
+    const term = document.getElementById('pm-search').value.toLowerCase();
+    const filtered = current.prompts.filter(p => p.name.toLowerCase().includes(term) || p.text.toLowerCase().includes(term));
+    renderPrompts(filtered);
+  }
+
+  loadData().then(data => {
+    current = data;
+    render();
+  });
+
+  document.getElementById('pm-search').addEventListener('input', render);
+
+  document.getElementById('pm-settings-btn').addEventListener('click', () => {
+    if (confirm('Export prompts to JSON?')) {
+      const blob = new Blob([JSON.stringify(current)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'prompts.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    } else {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = '.json';
+      input.onchange = () => {
+        const file = input.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+          try {
+            const data = JSON.parse(reader.result);
+            current = data;
+            saveCurrent();
+          } catch(err) {
+            alert('Invalid file');
+          }
+        };
+        reader.readAsText(file);
+      };
+      input.click();
+    }
+  });
+
+  document.getElementById('pm-new-folder').addEventListener('click', () => {
+    const name = prompt('Folder name');
+    if (!name) return;
+    const description = prompt('Folder description') || '';
+    const id = Date.now().toString();
+    current.folders.push({ id, name, description });
+    saveCurrent();
+  });
+
+  document.getElementById('pm-new-prompt').addEventListener('click', () => {
+    const name = prompt('Prompt name');
+    if (!name) return;
+    const description = prompt('Prompt description') || '';
+    const text = prompt('Prompt text');
+    if (!text) return;
+    const tagsInput = prompt('Tags (comma separated)') || '';
+    const folderId = prompt('Folder id (leave empty for none)') || '';
+    const id = Date.now().toString();
+    const tags = tagsInput
+      .split(',')
+      .map(t => t.trim())
+      .filter(Boolean);
+    current.prompts.push({
+      id,
+      name,
+      description,
+      text,
+      tags,
+      folderId,
+      favorite: false
+    });
+    saveCurrent();
+  });
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "ChatGPT Prompt Manager",
+  "description": "Manage and use your favorite ChatGPT prompts.",
+  "version": "1.0",
+  "action": {
+    "default_title": "Prompt Manager"
+  },
+  "permissions": ["storage", "activeTab", "scripting", "clipboardWrite"],
+  "content_scripts": [
+    {
+      "matches": ["https://chatgpt.com/*"],
+      "js": ["content_script.js"],
+      "css": ["style.css"]
+    }
+  ]
+}

--- a/extension/style.css
+++ b/extension/style.css
@@ -1,0 +1,113 @@
+/* Sidebar styles */
+#pm-toggle-btn {
+  position: fixed;
+  top: 50%;
+  right: 0;
+  background: #10a37f;
+  color: white;
+  padding: 8px;
+  border-radius: 4px 0 0 4px;
+  cursor: pointer;
+  z-index: 10000;
+  font-family: sans-serif;
+}
+
+#pm-sidebar {
+  position: fixed;
+  top: 0;
+  right: -320px;
+  width: 300px;
+  height: 100vh;
+  background: #263238;
+  color: #f1f1f1;
+  box-shadow: -2px 0 5px rgba(0,0,0,0.2);
+  padding: 10px;
+  overflow-y: auto;
+  z-index: 9999;
+  transition: right 0.3s ease;
+  font-family: sans-serif;
+}
+#pm-sidebar.open { right: 0; }
+
+.pm-search {
+  width: 100%;
+  padding: 6px;
+  margin-bottom: 10px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background: #37474f;
+  color: #fff;
+}
+
+.pm-actions {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.pm-actions button {
+  flex: 1;
+  margin-right: 4px;
+  padding: 4px;
+  border-radius: 4px;
+  border: 1px solid #555;
+  background: #455a64;
+  color: #fff;
+  cursor: pointer;
+}
+.pm-actions button:last-child { margin-right: 0; }
+
+.pm-folder-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.pm-folder {
+  width: 60px;
+  text-align: center;
+  cursor: pointer;
+  color: #f1f1f1;
+}
+.pm-folder img {
+  width: 24px;
+  height: 24px;
+}
+
+.pm-prompt-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pm-card {
+  background: #fff;
+  color: #000;
+  padding: 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.pm-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.pm-card-actions button {
+  margin-left: 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+#pm-settings-btn {
+  position: sticky;
+  bottom: 0;
+  width: 100%;
+  padding: 6px;
+  background: #37474f;
+  text-align: center;
+  cursor: pointer;
+  border-top: 1px solid #555;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- tweak README to document new features and dark theme
- add buttons to create prompts and folders
- store extra fields for prompts and folders
- update card editing for new fields
- refresh sidebar styles for better contrast

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_685d40ebaf148320bb42ea5a4f53eac6