### PR TITLE
Add modal forms and folder icons

### DIFF
--- a/extension/style.css
+++ b/extension/style.css
@@ -72,10 +72,15 @@
   text-align: center;
   cursor: pointer;
   color: #f1f1f1;
+  padding: 4px;
+  border: 1px solid #555;
+  border-radius: 4px;
 }
 .pm-folder img {
   width: 24px;
   height: 24px;
+  display: block;
+  margin: 0 auto 4px;
 }
 
 .pm-prompt-list {
@@ -118,4 +123,47 @@
   cursor: pointer;
   border-top: 1px solid #555;
   color: #fff;
+}
+
+/* Modal styles */
+.pm-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10001;
+}
+
+.pm-modal {
+  background: #37474f;
+  color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  width: 260px;
+}
+
+.pm-modal input[type="text"],
+.pm-modal textarea {
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 4px;
+  background: #455a64;
+  border: 1px solid #555;
+  color: #fff;
+  border-radius: 4px;
+}
+
+.pm-modal button {
+  margin-right: 4px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid #555;
+  background: #10a37f;
+  color: #fff;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- switch prompt/folder creation/editing to modal forms
- allow prompts to be associated with multiple folders via checkboxes
- let users pick an icon when creating or editing folders
- box style for folders and add modal styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685d497ea97c8320b2fb23b0ad51c0a3