### PR TITLE
Enhance sidebar UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ ChatGPT Prompt Manager is a Chrome extension that lets you store your favorite p
 - Add tags to prompts to ease their search
 - Button on the right side of chatGPT.com to open/close the prompt manager sidebar
 - Dark themed sidebar for better readability
+- Sidebar header and keyboard-accessible toggle for improved navigation
+- Search input with accessible label and Escape key to close the sidebar
 
 The prompts are organised as cards with buttons to modify, add/remove from favorites, delete and paste to the ChatGPT textbox.
 

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -1,8 +1,13 @@
 (function() {
   // Create toggle button
-  const toggleBtn = document.createElement('div');
+  const toggleBtn = document.createElement('button');
   toggleBtn.id = 'pm-toggle-btn';
   toggleBtn.textContent = 'Prompts';
+  toggleBtn.setAttribute('aria-label', 'Toggle prompt manager sidebar');
+  toggleBtn.setAttribute('aria-controls', 'pm-sidebar');
+  toggleBtn.setAttribute('title', 'Toggle prompt manager sidebar');
+  toggleBtn.setAttribute('tabindex', '0');
+  toggleBtn.setAttribute('aria-expanded', 'false');
   document.body.appendChild(toggleBtn);
 
   const SIDEBAR_WIDTH = 300;
@@ -16,8 +21,10 @@
   // Create sidebar
   const sidebar = document.createElement('div');
   sidebar.id = 'pm-sidebar';
+  sidebar.setAttribute('role', 'complementary');
   sidebar.innerHTML = `
-    <input type="text" placeholder="Search" class="pm-search" id="pm-search" />
+    <div class="pm-header"><h1>Prompt Manager</h1></div>
+    <input type="text" placeholder="Search" aria-label="Search prompts" class="pm-search" id="pm-search" />
     <div class="pm-actions">
       <button id="pm-new-folder">New Folder</button>
       <button id="pm-new-prompt">New Prompt</button>
@@ -29,9 +36,28 @@
   document.body.appendChild(sidebar);
   updateTogglePosition();
 
-  toggleBtn.addEventListener('click', () => {
+  function toggleSidebar() {
     sidebar.classList.toggle('open');
+    const expanded = sidebar.classList.contains('open');
+    toggleBtn.setAttribute('aria-expanded', expanded.toString());
     updateTogglePosition();
+    if (!expanded) {
+      toggleBtn.focus();
+    }
+  }
+
+  toggleBtn.addEventListener('click', toggleSidebar);
+  toggleBtn.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggleSidebar();
+    }
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && sidebar.classList.contains('open')) {
+      toggleSidebar();
+    }
   });
 
   // Utilities

--- a/extension/style.css
+++ b/extension/style.css
@@ -10,9 +10,15 @@
   cursor: pointer;
   z-index: 10000;
   font-family: sans-serif;
+  border: none;
   transform: rotate(-90deg);
   transform-origin: center;
   transition: right 0.3s ease;
+  outline: none;
+}
+
+#pm-toggle-btn:focus {
+  box-shadow: 0 0 0 2px #fff, 0 0 0 4px #10a37f;
 }
 
 #pm-sidebar {
@@ -31,6 +37,13 @@
   font-family: sans-serif;
 }
 #pm-sidebar.open { right: 0; }
+
+.pm-header {
+  text-align: center;
+  font-weight: 600;
+  font-size: 1.2em;
+  margin-bottom: 10px;
+}
 
 .pm-search {
   width: 100%;


### PR DESCRIPTION
## Summary
- convert the sidebar toggle element to a button
- add `aria-controls`, title, and accessible search label
- allow closing the sidebar with Escape and return focus
- remove button border for better styling
- document the new accessibility features

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685d49d60b9c832099d493697e6bae35