### PR TITLE
Improve sidebar layout and forms

### DIFF
--- a/extension/folderService.js
+++ b/extension/folderService.js
@@ -24,9 +24,12 @@
     const overlay = UiService.openModal(`
       <form id="pm-folder-form">
         <h3>${folder ? 'Edit' : 'New'} Folder</h3>
-        <input type="text" id="pm-folder-name" placeholder="Name" value="${f.name || ''}" required />
-        <input type="text" id="pm-folder-desc" placeholder="Description" value="${f.description || ''}" />
-        <input type="text" id="pm-folder-icon" placeholder="Icon" value="${f.icon || '📁'}" />
+        <label for="pm-folder-name">Name</label>
+        <input type="text" id="pm-folder-name" value="${f.name || ''}" required />
+        <label for="pm-folder-desc">Description</label>
+        <input type="text" id="pm-folder-desc" value="${f.description || ''}" />
+        <label for="pm-folder-icon">Icon</label>
+        <input type="text" id="pm-folder-icon" value="${f.icon || '📁'}" />
         <button type="submit">Save</button>
         <button type="button" id="pm-cancel-folder">Cancel</button>
       </form>

--- a/extension/main.js
+++ b/extension/main.js
@@ -19,7 +19,10 @@
   sidebar.id = 'pm-sidebar';
   sidebar.setAttribute('role', 'complementary');
   sidebar.innerHTML = `
-    <div class="pm-header"><h1>Prompt Manager</h1></div>
+    <div class="pm-header">
+      <h1>Prompt Manager</h1>
+      <button id="pm-settings-icon" title="Settings" aria-label="Settings">⚙️</button>
+    </div>
     <input type="text" placeholder="Search" aria-label="Search prompts" class="pm-search" id="pm-search" />
     <div class="pm-actions">
       <button id="pm-new-folder">New Folder</button>
@@ -27,7 +30,6 @@
     </div>
     <div class="pm-folder-list" id="pm-folders"></div>
     <div class="pm-prompt-list" id="pm-prompts"></div>
-    <div id="pm-settings-btn">Settings</div>
   `;
   document.body.appendChild(sidebar);
   updateTogglePosition();
@@ -87,7 +89,7 @@
 
   document.getElementById('pm-search').addEventListener('input', render);
 
-  document.getElementById('pm-settings-btn').addEventListener('click', () => {
+  document.getElementById('pm-settings-icon').addEventListener('click', () => {
     if (confirm('Export prompts to JSON?')) {
       const blob = new Blob([JSON.stringify(current)], { type: 'application/json' });
       const url = URL.createObjectURL(blob);

--- a/extension/promptService.js
+++ b/extension/promptService.js
@@ -51,10 +51,14 @@
     const overlay = UiService.openModal(`
       <form id="pm-prompt-form">
         <h3>${prompt ? 'Edit' : 'New'} Prompt</h3>
-        <input type="text" id="pm-prompt-name" placeholder="Name" value="${p.name || ''}" required />
-        <textarea id="pm-prompt-desc" placeholder="Description">${p.description || ''}</textarea>
-        <textarea id="pm-prompt-text" placeholder="Text" required>${p.text || ''}</textarea>
-        <input type="text" id="pm-prompt-tags" placeholder="Tags" value="${(p.tags || []).join(',')}" />
+        <label for="pm-prompt-name">Name</label>
+        <input type="text" id="pm-prompt-name" value="${p.name || ''}" required />
+        <label for="pm-prompt-desc">Description</label>
+        <textarea id="pm-prompt-desc">${p.description || ''}</textarea>
+        <label for="pm-prompt-text">Text</label>
+        <textarea id="pm-prompt-text" required>${p.text || ''}</textarea>
+        <label for="pm-prompt-tags">Tags</label>
+        <input type="text" id="pm-prompt-tags" value="${(p.tags || []).join(',')}" />
         <div style="margin-bottom:8px;">${foldersHtml}</div>
         <button type="submit">Save</button>
         <button type="button" id="pm-cancel-prompt">Cancel</button>

--- a/extension/style.css
+++ b/extension/style.css
@@ -39,16 +39,33 @@
 #pm-sidebar.open { right: 0; }
 
 .pm-header {
-  text-align: center;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   font-weight: 600;
   font-size: 1.2em;
-  margin-bottom: 10px;
+  margin-bottom: 16px;
+}
+.pm-header h1 {
+  margin: 0;
+  flex: 1;
+  text-align: center;
+}
+#pm-settings-icon {
+  position: absolute;
+  right: 0;
+  background: transparent;
+  border: none;
+  color: #f1f1f1;
+  cursor: pointer;
+  font-size: 1em;
 }
 
 .pm-search {
   width: 100%;
   padding: 6px;
-  margin-bottom: 12px;
+  margin-bottom: 16px;
   border: 1px solid #555;
   border-radius: 4px;
   background: #37474f;
@@ -58,7 +75,7 @@
 .pm-actions {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 12px;
+  margin-bottom: 16px;
 }
 
 .pm-actions button {
@@ -77,7 +94,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-bottom: 14px;
+  margin-bottom: 20px;
 }
 
 .pm-folder {
@@ -99,7 +116,7 @@
 .pm-prompt-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
 }
 
 .pm-card {
@@ -126,17 +143,6 @@
   margin-top: 6px;
 }
 
-#pm-settings-btn {
-  position: sticky;
-  bottom: 0;
-  width: 100%;
-  padding: 6px;
-  background: #37474f;
-  text-align: center;
-  cursor: pointer;
-  border-top: 1px solid #555;
-  color: #fff;
-}
 
 /* Modal styles */
 .pm-modal-overlay {
@@ -166,12 +172,18 @@
 .pm-modal input[type="text"],
 .pm-modal textarea {
   width: 100%;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
   padding: 4px;
   background: #455a64;
   border: 1px solid #555;
   color: #fff;
   border-radius: 4px;
+}
+
+.pm-modal label {
+  margin-top: 8px;
+  margin-bottom: 4px;
+  display: block;
 }
 
 .pm-modal button {


### PR DESCRIPTION
## Summary
- add a settings icon to the header and remove bottom settings button
- increase spacing between sidebar elements
- refine modal spacing and add labels on forms

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685d58656ecc8320bbf11f84b3009eba