### PR TITLE
Enhance folder filtering UI

### DIFF
--- a/extension/folderService.js
+++ b/extension/folderService.js
@@ -1,22 +1,29 @@
 (function() {
-  function renderFolders(folders, current, saveCurrent) {
+  function renderFolders(
+    folders,
+    current,
+    saveCurrent,
+    selectedIds,
+    onToggle,
+    onEdit
+  ) {
     const container = document.getElementById('pm-folders');
     container.innerHTML = '';
-    folders.slice(0,4).forEach(f => {
+    folders.forEach(f => {
       const div = document.createElement('div');
       div.className = 'pm-folder';
+      if (selectedIds.has(f.id)) div.classList.add('selected');
       div.innerHTML = `
         <div>${f.icon || '📁'}</div>
-        <div>${f.name}</div>`;
-      div.addEventListener('click', () => openFolderForm(f, current, saveCurrent));
+        <div>${f.name}</div>
+        <button class="pm-folder-edit" title="Edit">✎</button>`;
+      div.querySelector('.pm-folder-edit').addEventListener('click', e => {
+        e.stopPropagation();
+        onEdit(f);
+      });
+      div.addEventListener('click', () => onToggle(f.id));
       container.appendChild(div);
     });
-    if (folders.length > 4) {
-      const more = document.createElement('div');
-      more.className = 'pm-folder';
-      more.textContent = '...';
-      container.appendChild(more);
-    }
   }
 
   function openFolderForm(folder, current, saveCurrent) {

--- a/extension/main.js
+++ b/extension/main.js
@@ -23,13 +23,19 @@
       <h1>Prompt Manager</h1>
       <button id="pm-settings-btn" class="pm-settings-icon" aria-label="Settings" title="Settings">⚙</button>
     </div>
-    <input type="text" placeholder="Search" aria-label="Search prompts" class="pm-search" id="pm-search" />
-    <div class="pm-actions">
-      <button id="pm-new-folder">New Folder</button>
-      <button id="pm-new-prompt">New Prompt</button>
+    <div class="pm-section">
+      <input type="text" placeholder="Search" aria-label="Search prompts" class="pm-search" id="pm-search" />
     </div>
-    <div class="pm-folder-list" id="pm-folders"></div>
-    <div class="pm-prompt-list" id="pm-prompts"></div>
+    <div class="pm-section">
+      <div class="pm-actions">
+        <button id="pm-new-folder">New Folder</button>
+        <button id="pm-new-prompt">New Prompt</button>
+      </div>
+      <div class="pm-folder-list" id="pm-folders"></div>
+    </div>
+    <div class="pm-section">
+      <div class="pm-prompt-list" id="pm-prompts"></div>
+    </div>
   `;
   document.body.appendChild(sidebar);
   updateTogglePosition();
@@ -59,6 +65,16 @@
   });
 
   let current = { folders: [], prompts: [] };
+  const selectedFolders = new Set();
+
+  function toggleFolderSelection(id) {
+    if (selectedFolders.has(id)) {
+      selectedFolders.delete(id);
+    } else {
+      selectedFolders.add(id);
+    }
+    render();
+  }
 
   function saveCurrent() {
     StorageService.saveData(current.folders, current.prompts);
@@ -66,11 +82,25 @@
   }
 
   function render() {
-    FolderService.renderFolders(current.folders, current, saveCurrent);
-    const term = document.getElementById('pm-search').value.toLowerCase();
-    const filtered = current.prompts.filter(p =>
-      p.name.toLowerCase().includes(term) || p.text.toLowerCase().includes(term)
+    FolderService.renderFolders(
+      current.folders,
+      current,
+      saveCurrent,
+      selectedFolders,
+      toggleFolderSelection,
+      openFolderForm
     );
+    const term = document.getElementById('pm-search').value.toLowerCase();
+    let filtered = current.prompts.filter(
+      p =>
+        p.name.toLowerCase().includes(term) ||
+        p.text.toLowerCase().includes(term)
+    );
+    if (selectedFolders.size > 0) {
+      filtered = filtered.filter(p =>
+        p.folderIds && p.folderIds.some(id => selectedFolders.has(id))
+      );
+    }
     PromptService.renderPrompts(filtered, current, saveCurrent);
   }
 

--- a/extension/style.css
+++ b/extension/style.css
@@ -87,6 +87,16 @@
 }
 .pm-actions button:last-child { margin-right: 0; }
 
+.pm-section {
+  border-bottom: 1px solid #555;
+  padding-bottom: 16px;
+  margin-bottom: 16px;
+}
+
+#pm-sidebar .pm-section:last-of-type {
+  border-bottom: none;
+}
+
 .pm-folder-list {
   display: flex;
   flex-wrap: wrap;
@@ -102,6 +112,23 @@
   padding: 4px;
   border: 1px solid #555;
   border-radius: 4px;
+  position: relative;
+  transition: box-shadow 0.2s;
+}
+.pm-folder.selected {
+  border-color: #2196f3;
+  box-shadow: 0 0 0 2px #2196f3;
+}
+.pm-folder-edit {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: transparent;
+  border: none;
+  color: #f1f1f1;
+  cursor: pointer;
+  font-size: 0.8em;
+  padding: 0;
 }
 .pm-folder img {
   width: 24px;


### PR DESCRIPTION
## Summary
- create sections in the sidebar for better separation
- allow selecting multiple folders to filter prompts
- highlight selected folders and add an edit button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685d6032234c83209d1631eefe33a2cf