### PR TITLE
Allow deleting entries and toggle folders

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -23,16 +23,38 @@
       <h1>Prompt Manager</h1>
       <button id="pm-settings-btn" class="pm-settings-icon" aria-label="Settings" title="Settings">⚙</button>
     </div>
-    <input type="text" placeholder="Search" aria-label="Search prompts" class="pm-search" id="pm-search" />
-    <div class="pm-actions">
-      <button id="pm-new-folder">New Folder</button>
-      <button id="pm-new-prompt">New Prompt</button>
+    <div class="pm-section">
+      <input type="text" placeholder="Search" aria-label="Search prompts" class="pm-search" id="pm-search" />
     </div>
-    <div class="pm-folder-list" id="pm-folders"></div>
-    <div class="pm-prompt-list" id="pm-prompts"></div>
+    <div class="pm-section">
+      <div class="pm-actions">
+        <button id="pm-new-folder">New Folder</button>
+        <button id="pm-new-prompt">New Prompt</button>
+      </div>
+      <div class="pm-folder-list" id="pm-folders"></div>
+      <div class="pm-folder-toggle" id="pm-folder-toggle" tabindex="0" aria-label="More folders">▼</div>
+    </div>
+    <div class="pm-section">
+      <div class="pm-prompt-list" id="pm-prompts"></div>
+    </div>
   `;
   document.body.appendChild(sidebar);
   updateTogglePosition();
+
+  const folderToggle = document.getElementById('pm-folder-toggle');
+
+  function toggleFolderList() {
+    foldersCollapsed = !foldersCollapsed;
+    render();
+  }
+
+  folderToggle.addEventListener('click', toggleFolderList);
+  folderToggle.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggleFolderList();
+    }
+  });
 
   function toggleSidebar() {
     sidebar.classList.toggle('open');
@@ -59,6 +81,17 @@
   });
 
   let current = { folders: [], prompts: [] };
+  const selectedFolders = new Set();
+  let foldersCollapsed = true;
+
+  function toggleFolderSelection(id) {
+    if (selectedFolders.has(id)) {
+      selectedFolders.delete(id);
+    } else {
+      selectedFolders.add(id);
+    }
+    render();
+  }
 
   function saveCurrent() {
     StorageService.saveData(current.folders, current.prompts);
@@ -66,11 +99,33 @@
   }
 
   function render() {
-    FolderService.renderFolders(current.folders, current, saveCurrent);
-    const term = document.getElementById('pm-search').value.toLowerCase();
-    const filtered = current.prompts.filter(p =>
-      p.name.toLowerCase().includes(term) || p.text.toLowerCase().includes(term)
+    FolderService.renderFolders(
+      current.folders,
+      current,
+      saveCurrent,
+      selectedFolders,
+      toggleFolderSelection,
+      openFolderForm,
+      foldersCollapsed
     );
+    const toggle = document.getElementById('pm-folder-toggle');
+    if (current.folders.length > 3) {
+      toggle.style.display = 'block';
+      toggle.textContent = foldersCollapsed ? '▼' : '▲';
+    } else {
+      toggle.style.display = 'none';
+    }
+    const term = document.getElementById('pm-search').value.toLowerCase();
+    let filtered = current.prompts.filter(
+      p =>
+        p.name.toLowerCase().includes(term) ||
+        p.text.toLowerCase().includes(term)
+    );
+    if (selectedFolders.size > 0) {
+      filtered = filtered.filter(p =>
+        p.folderIds && p.folderIds.some(id => selectedFolders.has(id))
+      );
+    }
     PromptService.renderPrompts(filtered, current, saveCurrent);
   }
 

--- a/extension/promptService.js
+++ b/extension/promptService.js
@@ -69,13 +69,24 @@
         </div>
         <div class="pm-form-group">${foldersHtml}</div>
         <div class="pm-form-actions">
+          ${prompt ? '<button type="button" id="pm-delete-prompt">Delete</button>' : ''}
           <button type="submit">Save</button>
           <button type="button" id="pm-cancel-prompt">Cancel</button>
         </div>
       </form>
     `);
-    overlay.querySelector('#pm-cancel-prompt').onclick = () => overlay.remove();
-    overlay.querySelector('#pm-prompt-form').onsubmit = e => {
+  overlay.querySelector('#pm-cancel-prompt').onclick = () => overlay.remove();
+  const delBtn = overlay.querySelector('#pm-delete-prompt');
+  if (delBtn) {
+    delBtn.onclick = () => {
+      if (confirm('Delete this prompt?')) {
+        current.prompts = current.prompts.filter(p => p !== prompt);
+        saveCurrent();
+        overlay.remove();
+      }
+    };
+  }
+  overlay.querySelector('#pm-prompt-form').onsubmit = e => {
       e.preventDefault();
       const name = overlay.querySelector('#pm-prompt-name').value.trim();
       if (!name) return;

--- a/extension/style.css
+++ b/extension/style.css
@@ -87,21 +87,55 @@
 }
 .pm-actions button:last-child { margin-right: 0; }
 
+.pm-section {
+  border-bottom: 1px solid #555;
+  padding-bottom: 16px;
+  margin-bottom: 16px;
+}
+
+#pm-sidebar .pm-section:last-of-type {
+  border-bottom: none;
+}
+
 .pm-folder-list {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-bottom: 20px;
+  margin-bottom: 4px;
 }
 
 .pm-folder {
-  width: 60px;
+  flex: 1 0 calc(33.333% - 8px);
   text-align: center;
   cursor: pointer;
   color: #f1f1f1;
   padding: 4px;
   border: 1px solid #555;
   border-radius: 4px;
+  position: relative;
+  transition: box-shadow 0.2s;
+}
+.pm-folder.selected {
+  border-color: #2196f3;
+  box-shadow: 0 0 0 2px #2196f3;
+}
+.pm-folder-edit {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: transparent;
+  border: none;
+  color: #f1f1f1;
+  cursor: pointer;
+  font-size: 0.8em;
+  padding: 0;
+}
+.pm-folder-toggle {
+  display: none;
+  text-align: center;
+  cursor: pointer;
+  color: #f1f1f1;
+  margin-bottom: 12px;
 }
 .pm-folder img {
   width: 24px;


### PR DESCRIPTION
## Summary
- add delete button in folder and prompt forms
- allow folding folder list to show only first row
- show 3 folders per row and toggle arrow for expand/collapse

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685d6032234c83209d1631eefe33a2cf